### PR TITLE
Add 3D timeline web environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# 3D Timeline Environment
+
+This project contains a simple 3D scene rendered in the browser.
+The scene shows a white timeline with year marks from **1995** to **2025** against a dark gray background.
+
+## Running locally
+
+1. **Start a web server** (needed because modules are loaded via ES modules):
+
+   ```bash
+   npm start
+   ```
+
+   This uses Python's built-in HTTP server and serves files on [http://localhost:8000](http://localhost:8000).
+
+2. Open `http://localhost:8000` in your browser to view the scene.
+
+## Testing
+
+There are no automated tests yet. The command below prints a placeholder message:
+
+```bash
+npm test
+```
+
+## Structure
+
+- `index.html` – entry HTML file that loads the module.
+- `main.js` – sets up the Three.js scene and draws the timeline.
+- `package.json` – defines helper scripts for running the project.

--- a/Read.me
+++ b/Read.me
@@ -1,1 +1,0 @@
-Test file

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>3D Timeline</title>
+  <style>
+    body { margin: 0; overflow: hidden; background: #1e1e1e; }
+    canvas { display: block; }
+  </style>
+</head>
+<body>
+  <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,72 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160/build/three.module.js';
+import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.160/examples/jsm/controls/OrbitControls.js';
+import { CSS2DRenderer, CSS2DObject } from 'https://cdn.jsdelivr.net/npm/three@0.160/examples/jsm/renderers/CSS2DRenderer.js';
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x2a2a2a);
+
+const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+camera.position.set(0, 5, 15);
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+const labelRenderer = new CSS2DRenderer();
+labelRenderer.setSize(window.innerWidth, window.innerHeight);
+labelRenderer.domElement.style.position = 'absolute';
+labelRenderer.domElement.style.top = '0';
+document.body.appendChild(labelRenderer.domElement);
+
+const controls = new OrbitControls(camera, labelRenderer.domElement);
+controls.target.set(15, 0, 0);
+controls.update();
+
+const startYear = 1995;
+const endYear = 2025;
+const years = endYear - startYear;
+
+const material = new THREE.LineBasicMaterial({ color: 0xffffff });
+const points = [];
+points.push(new THREE.Vector3(0, 0, 0));
+points.push(new THREE.Vector3(years, 0, 0));
+const geometry = new THREE.BufferGeometry().setFromPoints(points);
+const line = new THREE.Line(geometry, material);
+scene.add(line);
+
+for (let i = 0; i <= years; i++) {
+  const x = i;
+  const tickGeo = new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(x, -0.2, 0),
+    new THREE.Vector3(x, 0.2, 0)
+  ]);
+  const tick = new THREE.Line(tickGeo, material);
+  scene.add(tick);
+
+  const year = startYear + i;
+  const div = document.createElement('div');
+  div.textContent = year;
+  div.style.color = 'white';
+  div.style.fontSize = '12px';
+  const label = new CSS2DObject(div);
+  label.position.set(x, 0.3, 0);
+  scene.add(label);
+}
+
+function onWindowResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  labelRenderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+window.addEventListener('resize', onWindowResize);
+
+function animate() {
+  requestAnimationFrame(animate);
+  controls.update();
+  renderer.render(scene, camera);
+  labelRenderer.render(scene, camera);
+}
+
+animate();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "timeline-3d-web",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "timeline-3d-web",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "timeline-3d-web",
+  "version": "1.0.0",
+  "description": "3D timeline environment for web testing",
+  "scripts": {
+    "start": "python3 -m http.server 8000",
+    "test": "echo 'No tests specified'"
+  }
+}


### PR DESCRIPTION
## Summary
- create Three.js scene with dark gray background and white timeline from 1995 to 2025
- add index.html and simple npm start script using Python HTTP server
- document running and testing steps

## Testing
- `npm install`
- `npm test`
- `npm start` (Python HTTP server)

------
https://chatgpt.com/codex/tasks/task_e_68b0a2197c58832a9b61a2cf57842bd4